### PR TITLE
fixed load font in static context throw an exception

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <groupId>net.sourceforge.barbecue</groupId>
   <artifactId>barbecue</artifactId>
   <packaging>jar</packaging>
-  <version>1.5-beta1</version>
+  <version>1.5-beta2</version>
   <description>barbecue</description>
   <organization>
     <name>barbecue.sourceforge.net</name>
@@ -75,6 +75,7 @@
 		<groupId>junit</groupId>
 		<artifactId>junit</artifactId>
 		<version>3.8.1</version>
+        <scope>test</scope>
   	</dependency>
   	<dependency>
 		<groupId>jdom</groupId>
@@ -85,11 +86,13 @@
 		<groupId>javax.servlet</groupId>
 		<artifactId>servlet-api</artifactId>
 		<version>2.2</version>
+        <scope>provided</scope>
   	</dependency>
   	<dependency>
 		<groupId>javax.portlet</groupId>
 		<artifactId>portlet-api</artifactId>
 		<version>2.0</version>
+        <scope>provided</scope>
   	</dependency>
   </dependencies>
 

--- a/src/java/net/sourceforge/barbecue/Main.java
+++ b/src/java/net/sourceforge/barbecue/Main.java
@@ -1,12 +1,12 @@
 
 package net.sourceforge.barbecue;
 
-import net.sourceforge.barbecue.env.DefaultEnvironment;
-import net.sourceforge.barbecue.output.SVGOutput;
+import net.sourceforge.barbecue.env.EnvironmentFactory;
 import net.sourceforge.barbecue.output.EPSOutput;
+import net.sourceforge.barbecue.output.SVGOutput;
 
-import java.io.OutputStream;
 import java.io.FileOutputStream;
+import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 
 /**
@@ -175,7 +175,7 @@ public class Main
 		{
 			// We need an output stream to write the image to...
 			OutputStreamWriter osw = new OutputStreamWriter(fos);
-			SVGOutput svg_out = new SVGOutput(osw, DefaultEnvironment.DEFAULT_FONT, java.awt.Color.black, java.awt.Color.white, 1, "in");
+			SVGOutput svg_out = new SVGOutput(osw, EnvironmentFactory.getEnvironment().getDefaultFont(), java.awt.Color.black, java.awt.Color.white, 1, "in");
 
 			barcode.output(svg_out);
 		}

--- a/src/java/net/sourceforge/barbecue/env/DefaultEnvironment.java
+++ b/src/java/net/sourceforge/barbecue/env/DefaultEnvironment.java
@@ -36,7 +36,7 @@ import java.awt.*;
  */
 public final class DefaultEnvironment implements Environment {
     /** The default font for drawing the barcode data underneath the bars */
-	public static final Font DEFAULT_FONT = new Font("Arial", Font.PLAIN, 20);
+	//public static final Font DEFAULT_FONT =null;// new Font("Arial", Font.PLAIN, 20);
 
 	/**
 	 * Returns the environment determined resolution for
@@ -52,6 +52,7 @@ public final class DefaultEnvironment implements Environment {
      * @return The default font for the environment
      */
     public Font getDefaultFont() {
-        return DEFAULT_FONT;
+		return Font.getFont("Arial");
+       // return DEFAULT_FONT;
     }
 }

--- a/src/java/net/sourceforge/barbecue/output/EPSOutput.java
+++ b/src/java/net/sourceforge/barbecue/output/EPSOutput.java
@@ -26,12 +26,12 @@
 
 package net.sourceforge.barbecue.output;
 
-import net.sourceforge.barbecue.env.DefaultEnvironment;
+import net.sourceforge.barbecue.env.EnvironmentFactory;
 
+import java.awt.*;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.Writer;
-import java.awt.*;
 
 /**
  * EPS outputter to output barcodes as Encapsulated Postscript  files.
@@ -51,7 +51,7 @@ public class EPSOutput extends AbstractOutput {
      * @param writer The Writer to output the EPS text to
      */
     public EPSOutput(Writer writer) {
-        super(DefaultEnvironment.DEFAULT_FONT, true, 1.0, Color.black, Color.white);
+        super(EnvironmentFactory.getEnvironment().getDefaultFont(), true, 1.0, Color.black, Color.white);
         this.writer = new BufferedWriter(writer);
         epsBody = new StringBuffer();
         epsHeader = new StringBuffer();


### PR DESCRIPTION
use of `static final Font DEFAULT_FONT = new Font(....)` cause error on macOS/JDK8 when class load.
So I use factory instead then problem gone.